### PR TITLE
Add EnumMember as a valid expression

### DIFF
--- a/lib/PropertyValue.js
+++ b/lib/PropertyValue.js
@@ -9,7 +9,8 @@ function PropertyValue(xml) {
     'Bool': {bool: true},
     'String': {},
     'Path': {},
-    'Property': {alreadyHandeled: true}
+    'Property': {alreadyHandeled: true},
+    'EnumMember': {}
   };
 
   var init = ParserCommon.initEntity.bind(this);


### PR DESCRIPTION
PropertyValues take all OData defined expressions.  EnumMember was missing.