### PR TITLE
Allowing for Strings in Collections

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -3,10 +3,12 @@ const ParserCommon = require('./ParserCommon');
 function Collection(xml) {
   this.PropertyPaths = [];
   this.Records = [];
+  this.Strings = [];
 
   this.validElements = {
     'PropertyPath': {parent: this.PropertyPaths, getText: true},
-    'Record': {parent: this.Records}
+    'Record': {parent: this.Records},
+    'String': {parent: this.Strings, passthru: true}
   };
   this.validAttributes = {
   };


### PR DESCRIPTION
Allows for String terms to be part of Collections. Just ignoring them for the time being.